### PR TITLE
Parse HTML content from API response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,12 +33,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.96"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,7 +1011,6 @@ name = "textty"
 version = "0.1.0"
 dependencies = [
  "ansi_term",
- "anyhow",
  "scraper",
  "serde",
  "serde-aux",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 ansi_term = "0.12.1"
-anyhow = "1.0.96"
 scraper = "0.23.1"
 serde = { version = "1.0.216", features = ["derive"] }
 serde-aux = "4.5.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,11 @@
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("transport error: {0:?}")]
+    Transport(#[from] ureq::Error),
+    #[error("invalid page number: {0}")]
+    InvalidPageNumber(u16),
+    #[error(transparent)]
+    IO(#[from] std::io::Error),
+    #[error("error parsing HTML: {0}")]
+    ParseHtml(String),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod error;
+pub mod page;
+pub mod ttv;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,16 @@
-use anyhow::bail;
-use std::env;
+use textty::{error::Error, page, ttv};
 
-mod page;
-mod ttv;
-
-fn main() -> anyhow::Result<()> {
-    let args: Vec<String> = env::args().collect();
+fn main() -> Result<(), Error> {
+    let args: Vec<String> = std::env::args().collect();
     let number: u16 = match args.get(1) {
-        Some(s) => match s.parse() {
-            Ok(n) => n,
-            Err(_) => {
-                bail!("Error: not a number: '{s}'");
+        Some(s) => {
+            if let Ok(n) = s.parse() {
+                n
+            } else {
+                eprintln!("Error: not a number: '{s}'");
+                std::process::exit(1);
             }
-        },
+        }
         None => 100, // home page
     };
 
@@ -20,7 +18,7 @@ fn main() -> anyhow::Result<()> {
 
     // Simple page display.
     if let Some(html) = response.content.first() {
-        let page = page::parse(html);
+        let page = page::parse(html)?;
         println!("{:-<40}", "");
         println!("{page}");
         println!("{:-<40}", "");


### PR DESCRIPTION
### Description

The [texttv.nu API ](https://texttv.nu/blogg/texttv-api) returns a HTML-page as `content`, which specified the colour coded contents of a Text TV page. This change set parses this information into a string that can be displayed in a terminal.

#### Changes

- Parse HTML with [`scraper`](https://crates.io/crates/scraper)
- Parse background and foreground colours from the `class` attributes and convert to ANSI codes; using [`ansi_term`](https://crates.io/crates/ansi_term).
- Add `app` query parameter for all API calls, according to [guidelines](https://texttv.nu/blogg/texttv-api).
- Add simple display of ANSI-coloured pages.

> [!NOTE]
> SVT Text TV graphics, such as the weather map ([page 401](https://texttv.nu/401)), are displayed on the [texttv.nu](https://texttv.nu/100) web using a set of GIF-files. These are currently discarded, but may be possible to convert to ASCII.