### PR TITLE
Guard against invalid textv.nu API parameters

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,8 @@ pub enum Error {
     Transport(#[from] ureq::Error),
     #[error("invalid page number: {0}")]
     InvalidPageNumber(u16),
+    #[error("invalid page range: expected lower page {lo} to be less than or equal to upper page {hi}")]
+    InvalidPageRange { lo: u16, hi: u16 },
     #[error(transparent)]
     IO(#[from] std::io::Error),
     #[error("error parsing HTML: {0}")]

--- a/src/page.rs
+++ b/src/page.rs
@@ -3,10 +3,6 @@ use crate::mosaic;
 use scraper::{Html, Selector};
 use std::str::FromStr;
 
-pub const HOME_PAGE_NR: u16 = 100;
-pub const MIN_PAGE_NR: u16 = 100;
-pub const MAX_PAGE_NR: u16 = 801;
-
 #[derive(Debug)]
 pub struct Span {
     pub style: SpanStyle,

--- a/src/texttv.rs
+++ b/src/texttv.rs
@@ -3,6 +3,7 @@
 use crate::error::Error;
 use serde::Deserialize;
 use serde_aux::field_attributes::deserialize_number_from_string;
+use std::cmp::PartialOrd;
 use std::fmt::{self, Display, Formatter};
 
 const BASE_URL: &str = "https://texttv.nu/api";
@@ -76,7 +77,7 @@ impl Display for PageResponse {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PageNumber(u16);
 
 impl TryFrom<u16> for PageNumber {
@@ -98,6 +99,9 @@ impl TryFrom<u16> for PageNumber {
 /// * Returns [`Error::InvaldPageRange`] if `lo` is not less than or equal to `hi`.
 /// * Returns [`ureq::Error`] if API request fails in the network, I/O, or application stack.
 pub fn get_page_range(lo: PageNumber, hi: PageNumber) -> Result<Vec<PageResponse>, Error> {
+    if hi > lo {
+        return Err(Error::InvalidPageRange { lo: lo.0, hi: hi.0 });
+    }
     let url = format!("{BASE_URL}/get/{}-{}", lo.0, hi.0);
     let mut response = ureq::get(&url).query("app", APP_ID).call()?;
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -319,13 +319,7 @@ impl App<'_> {
             KeyCode::Enter => {
                 let requested_page = self.input_buffer.parse::<u16>()?;
                 // Wrap page number to valid range.
-                if requested_page < texttv::MIN_PAGE_NR {
-                    self.page_nr = texttv::MIN_PAGE_NR;
-                } else if requested_page > texttv::MAX_PAGE_NR {
-                    self.page_nr = texttv::MAX_PAGE_NR;
-                } else {
-                    self.page_nr = requested_page;
-                }
+                self.page_nr = requested_page.clamp(texttv::MIN_PAGE_NR, texttv::MAX_PAGE_NR);
                 self.input_buffer.clear();
                 self.mode = Mode::Normal;
                 self.get_current_page()

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,15 +1,14 @@
-use crate::page;
-use crate::texttv;
+use crate::{page, texttv};
 use chrono::{DateTime, Local};
 use color_eyre::Result;
 use ratatui::{
+    DefaultTerminal, Frame,
     buffer::Buffer,
     crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind},
     layout::{Constraint, Flex, Layout, Rect},
     style::{Style, Stylize},
     text::{Line, Span, Text},
     widgets::{Block, Borders, Padding, Paragraph, Widget},
-    DefaultTerminal, Frame,
 };
 use std::borrow::Cow;
 
@@ -145,7 +144,7 @@ impl App<'_> {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            page_nr: page::HOME_PAGE_NR,
+            page_nr: texttv::HOME_PAGE_NR,
             ..Default::default()
         }
     }
@@ -153,7 +152,7 @@ impl App<'_> {
     /// Fetches the current page from the web, parses the page set into
     /// [`Text`] objects, and updates the app state.
     fn get_current_page(&mut self) -> Result<()> {
-        let response = texttv::get_page(self.page_nr)?;
+        let response = texttv::get_page(texttv::PageNumber::try_from(self.page_nr)?)?;
         self.next_nr = response.next_page;
         self.prev_nr = response.prev_page;
         self.page_index = 0;
@@ -320,10 +319,10 @@ impl App<'_> {
             KeyCode::Enter => {
                 let requested_page = self.input_buffer.parse::<u16>()?;
                 // Wrap page number to valid range.
-                if requested_page < page::MIN_PAGE_NR {
-                    self.page_nr = page::MIN_PAGE_NR;
-                } else if requested_page > page::MAX_PAGE_NR {
-                    self.page_nr = page::MAX_PAGE_NR;
+                if requested_page < texttv::MIN_PAGE_NR {
+                    self.page_nr = texttv::MIN_PAGE_NR;
+                } else if requested_page > texttv::MAX_PAGE_NR {
+                    self.page_nr = texttv::MAX_PAGE_NR;
                 } else {
                     self.page_nr = requested_page;
                 }


### PR DESCRIPTION
### Description

* Create a newtype, `PageNumber`, that implements limits for pages numbers that can be requested from the [texttv.nu](https://texttv.nu/blogg/texttv-api) API.
* Document API response types.
* Validate page range before sending request to API.