### PR TITLE
Keep state between http requests with ureq::Agent

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -57,6 +57,7 @@ impl From<page::FgColour> for ratatui::style::Color {
 /// The main application which holds the state and logic of the application.
 #[derive(Debug, Default)]
 pub struct App<'a> {
+    client: texttv::Client,
     page_set: Vec<Text<'a>>,
     page_index: usize,
     page_nr: u16,
@@ -154,7 +155,9 @@ impl App<'_> {
     /// Fetches the current page from the web, parses the page set into
     /// [`Text`] objects, and updates the app state.
     fn get_current_page(&mut self) -> Result<()> {
-        let response = texttv::get_page(texttv::PageNumber::try_from(self.page_nr)?)?;
+        let response = self
+            .client
+            .get_page(texttv::PageNumber::try_from(self.page_nr)?)?;
         self.next_nr = response.next_page;
         self.prev_nr = response.prev_page;
         self.page_index = 0;


### PR DESCRIPTION
### Description

Previously, every page request would result in constructing a new [ureq::Agent](https://docs.rs/ureq/latest/ureq/struct.Agent.html). This is not only unnecessary work in terms of allocation, but prevent the client to keep any kind of state between requests.

Storing an `Agent` as a `texttv.nu` client between requests makes changing page feel much more responsive. This solves a previous issue where holding down the next/previous page key would queue up a bunch of requests lagging behind command input.