### PR TITLE
Fix `get_page_range` check for hi/lo parameters

### DIFF
--- a/src/texttv.rs
+++ b/src/texttv.rs
@@ -116,7 +116,7 @@ impl Client {
         lo: PageNumber,
         hi: PageNumber,
     ) -> Result<Vec<PageResponse>, Error> {
-        if hi > lo {
+        if hi < lo {
             return Err(Error::InvalidPageRange { lo: lo.0, hi: hi.0 });
         }
         let url = format!("{BASE_URL}/get/{}-{}", lo.0, hi.0);


### PR DESCRIPTION
### Description

A page range is such that, for page numbers `lo`&ndash;`hi`, `lo <= hi`. The function `get_page_range` would previously return an error when `hi > lo`, which is the opposite of wanted behaviour. Flip the check so that an error is returned when `hi < lo` instead.

> [!NOTE]
> The function is never used in release builds, but is implemented to support the full functionality of the REST API.