### PR TITLE
Specify required rust version: 1.87.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 keywords = ["teletext", "tui"]
 categories = ["command-line-utilities"]
 edition = "2024"
+rust-version = "1.87.0"
 
 [dependencies]
 chrono = "0.4.40"


### PR DESCRIPTION
### Description

Usage of [`Vec::len`](https://doc.rust-lang.org/stable/std/vec/struct.Vec.html#method.len) in `const` contexts was stabilised in [v1.87.0](https://releases.rs/docs/1.87.0/).