### PR TITLE
Fix windows build artifact upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,6 @@ jobs:
   release:
     name: Release for ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
-    env:
-      GH_TOKEN: ${{ github.token }}
     strategy:
       matrix:
         include:
@@ -61,6 +59,7 @@ jobs:
           mv ${{ matrix.artifact }} ${{ matrix.name }}
 
       - name: Upload binary to release
-        run: |
-          gh release upload ${{ github.event.release.tag_name }} \
-            target/${{ matrix.target }}/release/${{ matrix.name }}
+        uses: softprops/action-gh-release@v2
+        if: github.ref_type == 'tag'
+        with:
+          files: target/${{ matrix.target }}/release/${{ matrix.name }}


### PR DESCRIPTION
### Description

The `windows-latest` runner throws an [error](https://github.com/lsjoeberg/textty/actions/runs/15228113532/job/42832619605) when attempting to upload an artifact to an existing release using the `gh` cli:

```
gh release upload <tag>
```

<details>

```
Run gh release upload v0.1.0 \
Post "https://uploads.github.com/repos/lsjoeberg/textty/releases/220795611/assets?label=&name=%5C": read \: Incorrect function.
You appear to be running in MinTTY without pseudo terminal support.
To learn about workarounds for this error, run:  gh help mintty
```

</details>

There seems to be an issue with the MinTTY terminal emulator used on the windows image. Instead of doing this manually, attempt to use an established action, [softprops/action-gh-release@v2](https://github.com/softprops/action-gh-release), to achieve the upload operation.