### PR TITLE
fix(texttv): use max page number 899

### DIFF
--- a/src/texttv.rs
+++ b/src/texttv.rs
@@ -80,15 +80,10 @@ impl Display for PageResponse {
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PageNumber(u16);
 
-impl TryFrom<u16> for PageNumber {
-    type Error = Error;
-
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        if (MIN_PAGE_NR..=MAX_PAGE_NR).contains(&value) {
-            Ok(Self(value))
-        } else {
-            Err(Error::InvalidPageNumber(value))
-        }
+impl From<u16> for PageNumber {
+    fn from(value: u16) -> Self {
+        let valid = u16::clamp(value, MIN_PAGE_NR, MAX_PAGE_NR);
+        Self(valid)
     }
 }
 

--- a/src/texttv.rs
+++ b/src/texttv.rs
@@ -11,7 +11,7 @@ const APP_ID: &str = "textty";
 
 pub const HOME_PAGE_NR: u16 = 100;
 pub const MIN_PAGE_NR: u16 = 100;
-pub const MAX_PAGE_NR: u16 = 801;
+pub const MAX_PAGE_NR: u16 = 899;
 
 #[derive(Debug, Deserialize)]
 pub struct PageResponse {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -157,7 +157,7 @@ impl App<'_> {
     fn get_current_page(&mut self) -> Result<()> {
         let response = self
             .client
-            .get_page(texttv::PageNumber::try_from(self.page_nr)?)?;
+            .get_page(texttv::PageNumber::from(self.page_nr))?;
         self.next_nr = response.next_page;
         self.prev_nr = response.prev_page;
         self.page_index = 0;


### PR DESCRIPTION
### Description

The ETSI/EBU standard ([EN 300 706](https://www.etsi.org/deliver/etsi_en/300700_300799/300706/01.02.01_60/en_300706v010201p.pdf)) allows page numbers 100&ndash;899. The previous maximum number was set to `801`, causing the application to error out if [texttv.nu](https://texttv.nu/) served pages above this limit.


From ETSI document [ETSI TR 100 287 v1.2.1 (2002-12)](https://www.etsi.org/deliver/etsi_tr/100200_100299/100287/01.02.01_60/tr_100287v010201p.pdf), p. 16:

> Any page address up to including hexadecimal FE with a sub-code up to and including 3F7E, can be used for a page
carrying data and can be specified as a linked page in a packet 27. However, normal decoders allow the user to enter
page numbers in the range 100 to 899 only.

Additionally, the conversion from the `u16` page number representation to the internal `PageNumber` type is now infallible, clamping the value in the valid range.